### PR TITLE
Add some useful templates

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -45,7 +45,11 @@ catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.
   # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
   # on how to get entities into the catalog.
-  locations: []
+  locations:
+    - type: file
+      target: ../../scaffolder-templates/*/template.yaml
+      rules:
+        - allow: [Template]
 
 auth:
   providers:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -86,9 +86,14 @@ catalog:
     - type: file
       target: ../../examples/entities.yaml
 
-    # Local example template
+    # Templates
     - type: file
       target: ../../examples/template/template.yaml
+      rules:
+        - allow: [Template]
+
+    - type: file
+      target: ../../scaffolder-templates/*/template.yaml
       rules:
         - allow: [Template]
 

--- a/scaffolder-templates/add-github-branch-protection/template.yaml
+++ b/scaffolder-templates/add-github-branch-protection/template.yaml
@@ -1,0 +1,73 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: add-branch-protection
+  title: Add Branch Protection
+  description: Turn on branch protection with some sensible defaults.
+
+spec:
+  owner: group:default/engineering
+  type: file
+
+  parameters:
+    - title: Where is your codebase?
+      required:
+        - repoName
+      properties:
+        repoHost:
+          type: string
+          default: github.com
+          ui:widget: hidden
+        repoOrg:
+          type: string
+          default: rrm-backstage-poc
+        repoName:
+          title: Repository name
+          type: string
+        branch:
+          title: Default branch
+          type: string
+          default: main
+
+    - title: Branch protection settings
+      properties:
+        allowForcePushes:
+          title: Allow force pushes
+          type: boolean
+          default: false
+        requiredApprovingRevewCount:
+          title: Approving reviews required to merge
+          type: number
+          default: 1
+
+
+  steps:
+    - id: callGitHubApi
+      name: Turn on branch protection
+      action: http:backstage:request
+      input:
+        method: 'PUT'
+        path: /proxy/mygithub/api/repos/${{ parameters.repoOrg }}/${{ parameters.repoName }}/branches/${{ parameters.branch }}/protection
+        headers:
+          content-type: 'application/json'
+        body:
+          required_status_checks: null
+          enforce_admins: true
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            required_approving_review_count: ${{ parameters.requiredApprovingRevewCount }}
+            require_last_push_approval: false
+          restrictions: null
+          required_linear_history: false
+          allow_force_pushes: ${{ parameters.allowForcePushes }}
+          allow_deletions: false
+          block_creations: false
+          required_conversation_resolution: false
+          lock_branch: false
+          allow_fork_syncing: true
+
+  output:
+    links:
+      - title: Go to branch protection settings
+        icon: github
+        url: https://github.com/${{ parameters.repoOrg }}/${{ parameters.repoName }}/settings/branches

--- a/scaffolder-templates/create-rfc/skeleton/template.md.njk
+++ b/scaffolder-templates/create-rfc/skeleton/template.md.njk
@@ -1,0 +1,24 @@
+# RFC-${{ values.rfcNumber }} - ${{ values.rfcTitle }}
+
+*Author(s)*:
+*Requested Reviewers*:
+*Status*: DRAFT
+
+## Abstract
+${{ values.abstract }}
+
+## Background
+
+## Non-Goals
+
+## Key Terms
+
+## Problem
+
+## Proposal
+
+## Technical Limitations
+
+## Open Questions
+
+## Outcomes and Forward References

--- a/scaffolder-templates/create-rfc/template.yaml
+++ b/scaffolder-templates/create-rfc/template.yaml
@@ -1,0 +1,67 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-rfc-template
+  title: Create a new RFC flavored markdown document
+  description: Create a new RFC flavored markdown document
+spec:
+  owner: group:default/engineering
+  type: service
+
+  parameters:
+    - title: Document front content
+      properties:
+        rfcNumber:
+          title: rfcNumber
+          type: string
+        rfcTitle:
+          title: RFC Title
+          type: string
+        abstract:
+          title: Document Abstract (optional draft version)
+          type: string
+          ui:widget: textarea
+    - title: Repository to place document
+      properties:
+        repoUrl:
+          content:
+            type: string
+          description: Name of repository
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+
+  steps:
+    - id: log-message
+      name: Log Message
+      action: debug:log
+      input:
+        message: Creating ${{ parameters.rfcNumber }}/index.md
+
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./create-rfc/skeleton
+        templateFileExtension: true
+        targetPath: docs/rfcs/${{ parameters.rfcNumber }}
+        values:
+          rfcNumber: ${{ parameters.rfcNumber }}
+          rfcTitle: ${{ parameters.rfcTitle }}
+          abstract: ${{ parameters.abstract }}
+
+    - id: move-rfc
+      action: fs:rename
+      input:
+        files:
+          - from: docs/rfcs/${{ parameters.rfcNumber }}/template.md
+            to: docs/rfcs/${{ parameters.rfcNumber }}/index.md
+
+    - id: create-pull-request
+      name: create-pull-request
+      action: publish:github:pull-request
+      input:
+        repoUrl: ${{ parameters.repoUrl }}
+        branchName: RFC-${{ parameters.rfcNumber }}_${{ parameters.rfcTitle | replace(" ", "-") | replace("\"", "") | replace ("'", "") | lower }}
+        title: RFC-${{ parameters.rfcNumber }} - ${{ parameters.rfcTitle }}
+        description: ${{ parameters.abstract }}


### PR DESCRIPTION
These templates are adapted from https://github.com/RoadieHQ/software-templates to be more Mozilla specific and meeting some of our standards.

The 2 templates I added are:

- RFC creation template (to add a RFC skeleton to a targetted repo)
- GitHub branch protection template