### PR TITLE
Enable scan for Firefox Monitor for Catalog

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -74,7 +74,7 @@ catalog:
         validateLocationsExist: true
         filters:
           branch: 'main'
-          repository: 'fxa' # Regex
+          repository: '(fxa|blurts-server)' # Regex
           visibility:
             - public
         schedule:


### PR DESCRIPTION
This should whitelist the Firefox Monitor app so that it can be catalogued in Backstage.

They added a catalogue info file [here](https://github.com/mozilla/blurts-server/blob/main/catalog-info.yaml).