### PR TITLE
[OBS-536]: Verify docker image build has no leaked github credentials

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ plugins/*/dist
 plugins/*/node_modules
 .yarn/cache
 .yarn/install-state.gz
+.git

--- a/.github/workflows/build-backstage-image.yaml
+++ b/.github/workflows/build-backstage-image.yaml
@@ -24,7 +24,9 @@ jobs:
       id-token: write
     steps:
       - id: checkout-application-repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@v2
       - id: gcp-auth
         uses: google-github-actions/auth@v2
@@ -48,4 +50,3 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-


### PR DESCRIPTION
Context: [OBS-536](https://mozilla-hub.atlassian.net/browse/OBS-536)