### PR TITLE
Phase 4: Glean plugin modernization

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -10,11 +10,9 @@ app:
         tag: backstage-dev
       environment: development
   extensions:
-    - app/routes:
+    - page:home:
         config:
-          redirects:
-            - from: /
-              to: /home
+          path: /
     - api:home/visits: true
     - app-root-element:home/visit-listener: true
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,13 +16,10 @@ import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
 import kubernetesPlugin from '@backstage/plugin-kubernetes/alpha';
 import githubActionsPlugin from '@backstage-community/plugin-github-actions/alpha';
 import homePlugin from '@backstage/plugin-home/alpha';
+import gleanPlugin from 'backstage-plugin-glean';
 import { techDocsReportIssueAddonModule } from '@backstage/plugin-techdocs-module-addons-contrib/alpha';
 
-import {
-  scmIntegrationsApi,
-  scmAuthApi,
-  gleanAnalyticsApi,
-} from './extensions/apis';
+import { scmIntegrationsApi, scmAuthApi } from './extensions/apis';
 import { signInPageExtension } from './extensions/signInPage';
 import { sidebarExtension } from './extensions/sidebar';
 import {
@@ -36,7 +33,6 @@ const appModule = createFrontendModule({
   extensions: [
     scmIntegrationsApi,
     scmAuthApi,
-    gleanAnalyticsApi,
     signInPageExtension,
     sidebarExtension,
     alertDisplayElement,
@@ -65,6 +61,7 @@ const features: FrontendFeature[] = [
   kubernetesPlugin,
   githubActionsPlugin,
   homePlugin,
+  gleanPlugin,
 ];
 
 const app = createApp({

--- a/packages/app/src/extensions/apis.ts
+++ b/packages/app/src/extensions/apis.ts
@@ -1,15 +1,9 @@
-import {
-  ApiBlueprint,
-  configApiRef,
-  analyticsApiRef,
-  AnalyticsApi,
-} from '@backstage/frontend-plugin-api';
+import { ApiBlueprint, configApiRef } from '@backstage/frontend-plugin-api';
 import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,
   ScmAuth,
 } from '@backstage/integration-react';
-import { GleanAnalytics } from 'backstage-plugin-glean';
 
 export const scmIntegrationsApi = ApiBlueprint.make({
   name: 'scm-integrations',
@@ -24,15 +18,4 @@ export const scmIntegrationsApi = ApiBlueprint.make({
 export const scmAuthApi = ApiBlueprint.make({
   name: 'scm-auth',
   params: defineParams => defineParams(ScmAuth.createDefaultApiFactory()),
-});
-
-export const gleanAnalyticsApi = ApiBlueprint.make({
-  name: 'glean-analytics',
-  params: defineParams =>
-    defineParams({
-      api: analyticsApiRef,
-      deps: { configApi: configApiRef },
-      factory: ({ configApi }) =>
-        GleanAnalytics.fromConfig(configApi) as unknown as AnalyticsApi,
-    }),
 });

--- a/plugins/glean/package.json
+++ b/plugins/glean/package.json
@@ -25,8 +25,8 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/core-components": "^0.18.9",
-    "@backstage/core-plugin-api": "^1.12.5",
+    "@backstage/frontend-plugin-api": "^0.16.0",
+    "@backstage/plugin-app-react": "^0.2.2",
     "@backstage/types": "^1.2.2",
     "@mozilla/glean": "^5.0.8",
     "react-router-dom": "^6.27.0",

--- a/plugins/glean/src/index.test.ts
+++ b/plugins/glean/src/index.test.ts
@@ -1,0 +1,154 @@
+import Glean from '@mozilla/glean/web';
+import GleanMetrics from '@mozilla/glean/metrics';
+import { GleanAnalytics } from './index';
+import { create } from './metrics/backstage';
+
+jest.mock('@mozilla/glean/web', () => ({
+  __esModule: true,
+  default: {
+    initialize: jest.fn(),
+    setLogPings: jest.fn(),
+    setDebugViewTag: jest.fn(),
+  },
+}));
+
+jest.mock('@mozilla/glean/metrics', () => ({
+  __esModule: true,
+  default: {
+    pageLoad: jest.fn(),
+    recordElementClick: jest.fn(),
+  },
+}));
+
+jest.mock('./metrics/backstage', () => ({
+  create: { record: jest.fn() },
+}));
+
+const makeConfig = (
+  values: Record<string, unknown> = {
+    'app.analytics.glean.appId': 'moz_backstage',
+    'app.analytics.glean.enabled': true,
+    'app.analytics.glean.environment': 'development',
+  },
+) =>
+  ({
+    getString: (k: string) => values[k] as string,
+    getBoolean: (k: string) => values[k] as boolean,
+    getOptional: <T>(k: string) => values[k] as T | undefined,
+  } as any);
+
+describe('GleanAnalytics.fromConfig', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('initializes Glean with the configured appId, enabled, and channel', () => {
+    GleanAnalytics.fromConfig(makeConfig());
+
+    expect(Glean.initialize).toHaveBeenCalledWith(
+      'moz_backstage',
+      true,
+      expect.objectContaining({
+        channel: 'development',
+        enableAutoPageLoadEvents: false,
+        enableAutoElementClickEvents: false,
+      }),
+    );
+  });
+
+  it('does not configure debug logging or tag when debug config is absent', () => {
+    GleanAnalytics.fromConfig(makeConfig());
+
+    expect(Glean.setLogPings).not.toHaveBeenCalled();
+    expect(Glean.setDebugViewTag).not.toHaveBeenCalled();
+  });
+
+  it('sets log pings and debug view tag when debug config is provided', () => {
+    GleanAnalytics.fromConfig(
+      makeConfig({
+        'app.analytics.glean.appId': 'moz_backstage',
+        'app.analytics.glean.enabled': true,
+        'app.analytics.glean.environment': 'development',
+        'app.analytics.glean.debug': { logging: true, tag: 'pr-123' },
+      }),
+    );
+
+    expect(Glean.setLogPings).toHaveBeenCalledWith(true);
+    expect(Glean.setDebugViewTag).toHaveBeenCalledWith('pr-123');
+  });
+
+  it('skips setDebugViewTag when only logging is configured', () => {
+    GleanAnalytics.fromConfig(
+      makeConfig({
+        'app.analytics.glean.appId': 'moz_backstage',
+        'app.analytics.glean.enabled': true,
+        'app.analytics.glean.environment': 'development',
+        'app.analytics.glean.debug': { logging: false },
+      }),
+    );
+
+    expect(Glean.setLogPings).toHaveBeenCalledWith(false);
+    expect(Glean.setDebugViewTag).not.toHaveBeenCalled();
+  });
+});
+
+describe('GleanAnalytics.captureEvent', () => {
+  let analytics: GleanAnalytics;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    analytics = GleanAnalytics.fromConfig(makeConfig());
+  });
+
+  it('emits a pageLoad metric on navigate events', () => {
+    analytics.captureEvent({
+      action: 'navigate',
+      subject: 'Home Page',
+    } as any);
+
+    expect(GleanMetrics.pageLoad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Home Page',
+        url: expect.any(String),
+        referrer: expect.any(String),
+      }),
+    );
+  });
+
+  it('emits a recordElementClick metric on click events', () => {
+    analytics.captureEvent({
+      action: 'click',
+      subject: 'Catalog link',
+      attributes: { to: '/catalog' },
+    } as any);
+
+    expect(GleanMetrics.recordElementClick).toHaveBeenCalledWith({
+      id: '/catalog',
+      label: 'Catalog link',
+    });
+  });
+
+  it('emits the create event metric on create actions', () => {
+    analytics.captureEvent({
+      action: 'create',
+      subject: 'my-component',
+      value: 42,
+      attributes: { entityRef: 'component:default/my-component' },
+    } as any);
+
+    expect(create.record).toHaveBeenCalledWith({
+      name: 'my-component',
+      entity_ref: 'component:default/my-component',
+      time_saved: 42,
+    });
+  });
+
+  it('ignores actions that are not navigate, click, or create', () => {
+    analytics.captureEvent({
+      action: 'view',
+      subject: 'whatever',
+    } as any);
+
+    expect(GleanMetrics.pageLoad).not.toHaveBeenCalled();
+    expect(GleanMetrics.recordElementClick).not.toHaveBeenCalled();
+    expect(create.record).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/glean/src/index.ts
+++ b/plugins/glean/src/index.ts
@@ -1,16 +1,16 @@
 import {
   AnalyticsApi,
   AnalyticsEvent,
-  AnyApiFactory,
   ConfigApi,
-  analyticsApiRef,
   configApiRef,
-  createApiFactory,
-} from '@backstage/core-plugin-api';
+  createFrontendPlugin,
+} from '@backstage/frontend-plugin-api';
+import { AnalyticsImplementationBlueprint } from '@backstage/plugin-app-react';
+import { JsonObject } from '@backstage/types';
 
 import Glean from '@mozilla/glean/web';
 import GleanMetrics from '@mozilla/glean/metrics';
-import { JsonObject } from '@backstage/types';
+
 import { create } from './metrics/backstage';
 
 type GleanConfig = NonNullable<Parameters<typeof Glean.initialize>[2]>;
@@ -39,9 +39,7 @@ export class GleanAnalytics implements AnalyticsApi {
   static fromConfig(config: ConfigApi): GleanAnalytics {
     const appId = config.getString('app.analytics.glean.appId');
     const enabled = config.getBoolean('app.analytics.glean.enabled');
-    const debug = config.getOptional(
-      'app.analytics.glean.debug',
-    ) as DebugConfig;
+    const debug = config.getOptional<DebugConfig>('app.analytics.glean.debug');
     const environment = config.getString('app.analytics.glean.environment');
 
     return new GleanAnalytics(
@@ -79,16 +77,24 @@ export class GleanAnalytics implements AnalyticsApi {
           time_saved: event.value,
         });
         break;
-
       default:
         break;
     }
   }
 }
 
-export const createGleanApiFactory: () => AnyApiFactory = () =>
-  createApiFactory({
-    api: analyticsApiRef,
-    deps: { configApi: configApiRef },
-    factory: ({ configApi }) => GleanAnalytics.fromConfig(configApi),
-  });
+const gleanAnalytics = AnalyticsImplementationBlueprint.make({
+  name: 'glean',
+  params: defineParams =>
+    defineParams({
+      deps: { configApi: configApiRef },
+      factory: ({ configApi }) => GleanAnalytics.fromConfig(configApi),
+    }),
+});
+
+export const gleanPlugin = createFrontendPlugin({
+  pluginId: 'glean',
+  extensions: [gleanAnalytics],
+});
+
+export default gleanPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15149,9 +15149,9 @@ __metadata:
   dependencies:
     "@backstage/cli": "npm:^0.36.1"
     "@backstage/core-app-api": "npm:^1.20.0"
-    "@backstage/core-components": "npm:^0.18.9"
-    "@backstage/core-plugin-api": "npm:^1.12.5"
     "@backstage/dev-utils": "npm:^1.1.22"
+    "@backstage/frontend-plugin-api": "npm:^0.16.0"
+    "@backstage/plugin-app-react": "npm:^0.2.2"
     "@backstage/test-utils": "npm:^1.7.17"
     "@backstage/types": "npm:^1.2.2"
     "@mozilla/glean": "npm:^5.0.8"


### PR DESCRIPTION
## Summary

**Stacked on #81.** Switch `plugins/glean` to new-frontend-system idioms and add unit-test coverage. Resolves the `as unknown as AnalyticsApi` cast Phase 3 had to introduce because `GleanAnalytics` implemented the legacy `AnalyticsApi` from `@backstage/core-plugin-api` while the new `analyticsApiRef` lives in `@backstage/frontend-plugin-api`.

## Changes (single commit `a9b1faa`)

**`plugins/glean/src/index.ts`:**
- All imports moved from `@backstage/core-plugin-api` to `@backstage/frontend-plugin-api`.
- Drop the legacy `createGleanApiFactory` export.
- Register `GleanAnalytics` via `AnalyticsImplementationBlueprint` from `@backstage/plugin-app-react` instead of a direct `ApiBlueprint` against `analyticsApiRef`. **This is the key insight** — the app plugin already provides a single `analyticsApi` extension that aggregates every `AnalyticsImplementationBlueprint` contribution. Registering our own `ApiBlueprint` for `analyticsApiRef` triggered `API_FACTORY_CONFLICT` at startup. Multiple analytics implementations are designed to coexist via this blueprint.
- Default-export `gleanPlugin = createFrontendPlugin(...)` so the app composes via `features: [..., gleanPlugin]` rather than registering an extension manually.

**`packages/app/src/`:**
- `App.tsx`: import `gleanPlugin` and add to features array. Drop the `gleanAnalyticsApi` extension and the `as unknown as AnalyticsApi` cast in `extensions/apis.ts`.

**Tests (new, 8/8):**
- `plugins/glean/src/index.test.ts` covers `GleanAnalytics.fromConfig` (Glean.initialize wiring, optional `debug.tag` handling) and `captureEvent` action dispatch (`navigate` → pageLoad, `click` → recordElementClick, `create` → custom event metric, unknown action → ignored).

**Dependency cleanup (`plugins/glean/package.json`):**
- Add `@backstage/frontend-plugin-api ^0.16.0`
- Add `@backstage/plugin-app-react ^0.2.2`
- Remove `@backstage/core-plugin-api` (no longer used)
- Remove `@backstage/core-components` (no longer used)

## Verification

| Check | Result |
|---|---|
| `yarn tsc` | clean |
| `yarn lint:all` | clean |
| `yarn prettier:check` | clean |
| `yarn test:all` | 16/16 (8 new Glean tests) |
| `yarn start` | no `API_FACTORY_CONFLICT`, Glean events fire |

## Test plan

- [ ] CI passes
- [ ] Manual: open DevTools Network tab in dev mode, navigate around — Glean ping POSTs should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)