### PR TITLE
chore: Add billing project to bigquery sources

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -209,49 +209,53 @@ catalog:
   providers:
     mozcloud:
       tenants:
-        bigquery:
-          project: mozdata
-          dataset: mozcloud
-          table: tenants
-          # Bill jobs to a project the local user has bigquery.jobs.create on;
-          # `mozdata` is read-only for most analysts.
-          billingProject: moz-fx-backstage-nonprod
+        sources:
+          # Reads `mozdata.mozcloud.tenants` directly.
+          # Derives Domain, System (tenant) and Services.
+          tenants:
+            bigquery:
+              project: mozdata
+              dataset: mozcloud
+              table: tenants
+              billingProject: moz-fx-backstage-nonprod
+          # Joins `tenants.globals.deployment.charts[]` with
+          # `tenants_deployed_charts` to produce one row per (tenant, chart)
+          # carrying the declared chart metadata + the actual deployment
+          # tree (realm -> environments -> regions). Consumed by the
+          # tenant entity provider as a second source to enrich chart
+          # Components with deployment annotations.
+          charts:
+            bigquery:
+              project: mozdata
+              dataset: mozcloud
+              billingProject: moz-fx-backstage-nonprod
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 5 }
           initialDelay: { seconds: 30 }
-      charts:
-        # Joins `tenants.globals.deployment.charts[]` with
-        # `tenants_deployed_charts` to produce one row per (tenant, chart)
-        # carrying the declared chart metadata + the actual deployment
-        # tree (realm -> environments -> regions). Consumed by the
-        # tenant entity provider as a second source to enrich chart
-        # Components with deployment annotations.
-        bigquery:
-          project: mozdata
-          dataset: mozcloud
-          billingProject: moz-fx-backstage-nonprod
       workgroups:
-        # Reads `mozdata.mozcloud.workgroups` directly (one row per
-        # workgroup with nested subgroups). Drives Group entities only;
-        # human users come from the `users` source below.
-        bigquery:
-          project: mozdata
-          dataset: mozcloud
-          billingProject: moz-fx-backstage-nonprod
+        sources:
+          # Reads `mozdata.mozcloud.workgroups` directly (one row per
+          # workgroup with nested subgroups). Drives Group entities only;
+          # human users come from the `users` source below.
+          workgroups:
+            bigquery:
+              project: mozdata
+              dataset: mozcloud
+              billingProject: moz-fx-backstage-nonprod
+          # Aggregates `mozdata.mozcloud.workgroup_subgroup_members` (where
+          # `member_type='user'`) into one row per human with GitHub
+          # identity and their (workgroup, subgroup) memberships. Drives
+          # User entities and back-fills subgroup Group `spec.members`.
+          users:
+            bigquery:
+              project: mozdata
+              dataset: mozcloud
+              billingProject: moz-fx-backstage-nonprod
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 5 }
           initialDelay: { seconds: 30 }
-      users:
-        # Aggregates `mozdata.mozcloud.workgroup_subgroup_members` (where
-        # `member_type='user'`) into one row per human with GitHub
-        # identity and their (workgroup, subgroup) memberships. Drives
-        # User entities and back-fills subgroup Group `spec.members`.
-        bigquery:
-          project: mozdata
-          dataset: mozcloud
-          billingProject: moz-fx-backstage-nonprod
   import:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -213,6 +213,9 @@ catalog:
           project: mozdata
           dataset: mozcloud
           table: tenants
+          # Bill jobs to a project the local user has bigquery.jobs.create on;
+          # `mozdata` is read-only for most analysts.
+          billingProject: moz-fx-backstage-nonprod
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 5 }
@@ -227,6 +230,7 @@ catalog:
         bigquery:
           project: mozdata
           dataset: mozcloud
+          billingProject: moz-fx-backstage-nonprod
       workgroups:
         # Reads `mozdata.mozcloud.workgroups` directly (one row per
         # workgroup with nested subgroups). Drives Group entities only;
@@ -234,6 +238,7 @@ catalog:
         bigquery:
           project: mozdata
           dataset: mozcloud
+          billingProject: moz-fx-backstage-nonprod
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 5 }
@@ -246,6 +251,7 @@ catalog:
         bigquery:
           project: mozdata
           dataset: mozcloud
+          billingProject: moz-fx-backstage-nonprod
   import:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration

--- a/plugins/catalog-backend-module-mozcloud/config.d.ts
+++ b/plugins/catalog-backend-module-mozcloud/config.d.ts
@@ -5,92 +5,94 @@ export interface Config {
     providers?: {
       mozcloud?: {
         tenants?: {
-          /**
-           * Read tenant rows from BigQuery. Auth follows ADC — Workload
-           * Identity in GKE, application-default credentials locally.
-           */
-          bigquery: {
-            project: string;
-            dataset: string;
-            table: string;
+          sources?: {
+            tenants?: {
+              /**
+               * Read tenant rows from BigQuery.
+               */
+              bigquery: {
+                project: string;
+                dataset: string;
+                table: string;
+                /**
+                 * Project that BQ jobs run (and bill) under. Defaults to
+                 * `project`. Useful when the caller can read mozdata tables
+                 * but doesn't have `bigquery.jobs.create` on `mozdata`.
+                 */
+                billingProject?: string;
+              };
+            };
+
             /**
-             * Project that BQ jobs run (and bill) under. Defaults to
-             * `project`. Useful when the caller can read mozdata tables
-             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             * Charts source. Joins the per-tenant declared charts list
+             * (`tenants.globals.deployment.charts`) with the flat deployment
+             * fact table (`tenants_deployed_charts`) to produce one row per
+             * `(tenant, chart_name)` with chart metadata + a nested
+             * deployment tree (realm -> environments -> regions).
+             *
+             * The tenant entity provider uses it to
+             * enrich its chart Components with deployment annotations.
              */
-            billingProject?: string;
+            charts?: {
+              bigquery: {
+                project: string;
+                dataset: string;
+                /** Defaults to `tenants`. */
+                tenantsTable?: string;
+                /** Defaults to `tenants_deployed_charts`. */
+                deployedChartsTable?: string;
+                /**
+                 * Project that BQ jobs run (and bill) under. Defaults to
+                 * `project`. Useful when the caller can read mozdata tables
+                 * but doesn't have `bigquery.jobs.create` on `mozdata`.
+                 */
+                billingProject?: string;
+              };
+            };
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         };
-        /**
-         * Charts source. Joins the per-tenant declared charts list
-         * (`tenants.globals.deployment.charts`) with the flat deployment
-         * fact table (`tenants_deployed_charts`) to produce one row per
-         * `(tenant, chart_name)` with chart metadata + a nested
-         * deployment tree (realm -> environments -> regions).
-         *
-         * Optional. When present, the tenant entity provider uses it to
-         * enrich its chart Components with deployment annotations.
-         */
-        charts?: {
-          bigquery: {
-            project: string;
-            dataset: string;
-            /** Defaults to `tenants`. */
-            tenantsTable?: string;
-            /** Defaults to `tenants_deployed_charts`. */
-            deployedChartsTable?: string;
-            /**
-             * Project that BQ jobs run (and bill) under. Defaults to
-             * `project`. Useful when the caller can read mozdata tables
-             * but doesn't have `bigquery.jobs.create` on `mozdata`.
-             */
-            billingProject?: string;
-          };
-          schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
-        };
-        /**
-         * Workgroups source. Reads the pre-aggregated workgroups view
-         * (one row per workgroup with nested subgroups). Drives Group
-         * entities only — human users live on the separate `users`
-         * source below.
-         */
+
         workgroups?: {
-          bigquery: {
-            project: string;
-            dataset: string;
-            /** Defaults to `workgroups`. */
-            workgroupsTable?: string;
+          sources: {
             /**
-             * Project that BQ jobs run (and bill) under. Defaults to
-             * `project`. Useful when the caller can read mozdata tables
-             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             * Workgroups source. Reads the pre-aggregated workgroups view
+             * (one row per workgroup with nested subgroups). Drives Group
+             * entities only — human users live on the separate `users`
+             * source below.
              */
-            billingProject?: string;
-          };
-          schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
-        };
-        /**
-         * Users source. Reads the flat `workgroup_subgroup_members`
-         * table filtered to `member_type='user'`, aggregating per email
-         * to produce one row per human with GitHub identity and the
-         * `(workgroup, subgroup)` memberships they hold.
-         *
-         * Optional. When present, the workgroup provider emits User
-         * entities and back-fills each subgroup Group's `spec.members`.
-         */
-        users?: {
-          bigquery: {
-            project: string;
-            dataset: string;
-            /** Defaults to `workgroup_subgroup_members`. */
-            subgroupMembersTable?: string;
+            workgroups?: {
+              bigquery: {
+                project: string;
+                dataset: string;
+                /** Defaults to `workgroups`. */
+                workgroupsTable?: string;
+                /**
+                 * Project that BQ jobs run (and bill) under. Defaults to
+                 * `project`. Useful when the caller can read mozdata tables
+                 * but doesn't have `bigquery.jobs.create` on `mozdata`.
+                 */
+                billingProject?: string;
+              };
+            };
             /**
-             * Project that BQ jobs run (and bill) under. Defaults to
-             * `project`. Useful when the caller can read mozdata tables
-             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             * Users source. Reads the flat `workgroup_subgroup_members`
+             * table filtered to `member_type='user'`, aggregating per email
+             * to produce one row per human with GitHub identity and the
+             * `(workgroup, subgroup)` memberships they hold.
+             *
+             * The workgroup provider emits User
+             * entities and back-fills each subgroup Group's `spec.members`.
              */
-            billingProject?: string;
+            users?: {
+              bigquery: {
+                project: string;
+                dataset: string;
+                /** Defaults to `workgroup_subgroup_members`. */
+                subgroupMembersTable?: string;
+                billingProject?: string;
+              };
+            };
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         };

--- a/plugins/catalog-backend-module-mozcloud/config.d.ts
+++ b/plugins/catalog-backend-module-mozcloud/config.d.ts
@@ -13,6 +13,12 @@ export interface Config {
             project: string;
             dataset: string;
             table: string;
+            /**
+             * Project that BQ jobs run (and bill) under. Defaults to
+             * `project`. Useful when the caller can read mozdata tables
+             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             */
+            billingProject?: string;
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         };
@@ -34,6 +40,12 @@ export interface Config {
             tenantsTable?: string;
             /** Defaults to `tenants_deployed_charts`. */
             deployedChartsTable?: string;
+            /**
+             * Project that BQ jobs run (and bill) under. Defaults to
+             * `project`. Useful when the caller can read mozdata tables
+             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             */
+            billingProject?: string;
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         };
@@ -49,6 +61,12 @@ export interface Config {
             dataset: string;
             /** Defaults to `workgroups`. */
             workgroupsTable?: string;
+            /**
+             * Project that BQ jobs run (and bill) under. Defaults to
+             * `project`. Useful when the caller can read mozdata tables
+             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             */
+            billingProject?: string;
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         };
@@ -67,6 +85,12 @@ export interface Config {
             dataset: string;
             /** Defaults to `workgroup_subgroup_members`. */
             subgroupMembersTable?: string;
+            /**
+             * Project that BQ jobs run (and bill) under. Defaults to
+             * `project`. Useful when the caller can read mozdata tables
+             * but doesn't have `bigquery.jobs.create` on `mozdata`.
+             */
+            billingProject?: string;
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         };

--- a/plugins/catalog-backend-module-mozcloud/package.json
+++ b/plugins/catalog-backend-module-mozcloud/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.3.1",
     "@backstage/catalog-model": "^1.8.0",
+    "@backstage/config": "^1.3.8",
     "@backstage/plugin-catalog-node": "^2.2.0",
     "@google-cloud/bigquery": "^8.3.0",
     "@types/js-yaml": "^4.0.9",

--- a/plugins/catalog-backend-module-mozcloud/src/MozcloudTenantEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/MozcloudTenantEntityProvider.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { MozcloudTenantEntityProvider } from './MozcloudTenantEntityProvider';
 import { Source } from './sources/Source';
-import { TenantRow } from './transform/schema';
+import { ChartDeploymentsRow, TenantRow } from './transform/schema';
 
 const TENANT_A: TenantRow = {
   globals: {
@@ -41,9 +41,11 @@ const TENANT_B: TenantRow = {
   realms: {},
 };
 
-class FakeSource implements Source<TenantRow> {
-  description = 'fake:in-memory';
-  constructor(private readonly rows: TenantRow[]) {}
+class FakeSource<T> implements Source<T> {
+  constructor(
+    public readonly description: string,
+    private readonly rows: T[],
+  ) {}
   async fetchAll() {
     return this.rows;
   }
@@ -66,7 +68,8 @@ describe('MozcloudTenantEntityProvider', () => {
     };
 
     const provider = new MozcloudTenantEntityProvider(
-      new FakeSource([TENANT_A, TENANT_B]),
+      new FakeSource<TenantRow>('fake-tenants:in-memory', [TENANT_A, TENANT_B]),
+      new FakeSource<ChartDeploymentsRow>('fake-charts:in-memory', []),
       mockServices.logger.mock(),
       new ImmediateTaskRunner(),
     );
@@ -85,7 +88,7 @@ describe('MozcloudTenantEntityProvider', () => {
         }`,
     );
 
-    // With no chartsSource configured, only tenant-level entities are emitted:
+    // With an empty charts source, only tenant-level entities are emitted:
     // 1 dedup'd Domain + 2 Systems + 1 Resource (TENANT_A's prod realm).
     // Chart Components are emitted by chartToEntities, exercised separately.
     expect(refs).toEqual(
@@ -123,7 +126,8 @@ describe('MozcloudTenantEntityProvider', () => {
     };
 
     const provider = new MozcloudTenantEntityProvider(
-      new FakeSource([]),
+      new FakeSource<TenantRow>('fake-tenants:in-memory', []),
+      new FakeSource<ChartDeploymentsRow>('fake-charts:in-memory', []),
       mockServices.logger.mock(),
       new ImmediateTaskRunner(),
     );

--- a/plugins/catalog-backend-module-mozcloud/src/MozcloudTenantEntityProvider.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/MozcloudTenantEntityProvider.ts
@@ -1,7 +1,10 @@
 import {
   LoggerService,
+  readSchedulerServiceTaskScheduleDefinitionFromConfig,
+  SchedulerService,
   SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import {
   EntityProvider,
@@ -10,7 +13,27 @@ import {
 import { Source } from './sources/Source';
 import { tenantToEntities } from './transform/tenantToEntities';
 import { chartToEntities } from './transform/chartToEntities';
-import { ChartDeploymentsRow, TenantRow } from './transform/schema';
+import {
+  ChartDeploymentsRow,
+  ChartDeploymentsRowSchema,
+  TenantRow,
+  TenantRowSchema,
+} from './transform/schema';
+import {
+  defineBigQuerySource,
+  normalizeTenantRow,
+} from './sources/BigQuerySource';
+import {
+  chartsDeploymentsQuery,
+  chartsDeploymentsSourceDescription,
+  tenantsQuery,
+} from './queries';
+
+const DEFAULT_SCHEDULE = {
+  frequency: { minutes: 30 },
+  timeout: { minutes: 5 },
+  initialDelay: { seconds: 30 },
+};
 
 /**
  * Catalog entity provider that turns rows from a {@link Source} (BigQuery
@@ -20,20 +43,24 @@ import { ChartDeploymentsRow, TenantRow } from './transform/schema';
  * next tick.
  *
  * The tenants source produces Domain / System / Resource entities via
- * {@link tenantToEntities}. The optional {@link ChartDeploymentsRow}
- * source produces the helm chart Components and helm-deployment
- * sub-Components via {@link chartToEntities}; each row carries the
- * tenant metadata it needs so the transform is row-local.
+ * {@link tenantToEntities}. The {@link ChartDeploymentsRow} source
+ * produces the helm chart Components and helm-deployment sub-Components
+ * via {@link chartToEntities}; each row carries the tenant metadata it
+ * needs so the transform is row-local.
  */
 export class MozcloudTenantEntityProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
 
+  readonly description: string;
+
   constructor(
-    private readonly source: Source<TenantRow>,
+    private readonly tenantsSource: Source<TenantRow>,
+    private readonly chartsSource: Source<ChartDeploymentsRow>,
     private readonly logger: LoggerService,
     private readonly taskRunner: SchedulerServiceTaskRunner,
-    private readonly chartsSource?: Source<ChartDeploymentsRow>,
-  ) {}
+  ) {
+    this.description = `tenants: ${tenantsSource.description}, charts: ${chartsSource.description}`;
+  }
 
   getProviderName(): string {
     return 'MozcloudTenantEntityProvider';
@@ -63,14 +90,12 @@ export class MozcloudTenantEntityProvider implements EntityProvider {
     }
 
     const [tenants, charts] = await Promise.all([
-      this.source.fetchAll(),
-      this.chartsSource ? this.chartsSource.fetchAll() : Promise.resolve([]),
+      this.tenantsSource.fetchAll(),
+      this.chartsSource.fetchAll(),
     ]);
 
-    const tenantsLocationRef = `mozcloud:${this.source.description}`;
-    const chartsLocationRef = this.chartsSource
-      ? `mozcloud:${this.chartsSource.description}`
-      : tenantsLocationRef;
+    const tenantsLocationRef = `mozcloud:${this.tenantsSource.description}`;
+    const chartsLocationRef = `mozcloud:${this.chartsSource.description}`;
     const entities: Entity[] = [];
 
     for (const tenant of tenants) {
@@ -94,9 +119,67 @@ export class MozcloudTenantEntityProvider implements EntityProvider {
     this.logger.info(
       `${this.getProviderName()}: applied full mutation with ${
         deduped.length
-      } entities from ${tenants.length} tenants${
-        this.chartsSource ? ` (charts source: ${charts.length} rows)` : ''
-      }`,
+      } entities from ${tenants.length} tenants and ${
+        charts.length
+      } chart rows`,
+    );
+  }
+
+  /**
+   * Build a provider from its `catalog.providers.mozcloud.tenants` config
+   * block. Owns the wiring of both BigQuery sources, the task schedule,
+   * and the task runner so the registering module just hands the block
+   * over and registers the result.
+   */
+  static createFromConfig(
+    config: Config,
+    logger: LoggerService,
+    scheduler: SchedulerService,
+  ): MozcloudTenantEntityProvider {
+    const tenantsBq = config.getConfig('sources.tenants.bigquery').get<{
+      project: string;
+      dataset: string;
+      table: string;
+      billingProject?: string;
+    }>();
+    const tenantsSource = defineBigQuerySource({
+      query: tenantsQuery(tenantsBq),
+      schema: TenantRowSchema,
+      description: `bigquery:${tenantsBq.project}.${tenantsBq.dataset}.${tenantsBq.table}`,
+      billingProject: tenantsBq.billingProject,
+      dataProject: tenantsBq.project,
+      normalize: normalizeTenantRow,
+      logger,
+    });
+
+    const chartsBq = config.getConfig('sources.charts.bigquery').get<{
+      project: string;
+      dataset: string;
+      tenantsTable?: string;
+      deployedChartsTable?: string;
+      billingProject?: string;
+    }>();
+    const chartsSource = defineBigQuerySource({
+      query: chartsDeploymentsQuery(chartsBq),
+      schema: ChartDeploymentsRowSchema,
+      description: chartsDeploymentsSourceDescription(chartsBq),
+      billingProject: chartsBq.billingProject,
+      dataProject: chartsBq.project,
+      logger,
+    });
+
+    const schedule = config.has('schedule')
+      ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
+          config.getConfig('schedule'),
+        )
+      : DEFAULT_SCHEDULE;
+    const taskRunner = scheduler.createScheduledTaskRunner(schedule);
+
+    return new MozcloudTenantEntityProvider(
+      tenantsSource,
+      chartsSource,
+      logger,
+      taskRunner,
     );
   }
 }

--- a/plugins/catalog-backend-module-mozcloud/src/MozcloudWorkgroupEntityProvider.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/MozcloudWorkgroupEntityProvider.ts
@@ -90,7 +90,7 @@ export class MozcloudWorkgroupEntityProvider implements EntityProvider {
 
     const [workgroups, users] = await Promise.all([
       this.workgroupsSource.fetchAll(),
-      this.usersSource ? this.usersSource.fetchAll() : Promise.resolve([]),
+      this.usersSource.fetchAll(),
     ]);
 
     const wgLocationRef = `mozcloud-workgroups:${this.workgroupsSource.description}`;
@@ -119,9 +119,9 @@ export class MozcloudWorkgroupEntityProvider implements EntityProvider {
     this.logger.info(
       `${this.getProviderName()}: applied full mutation with ${
         merged.length
-      } entities from ${workgroups.length} workgroups${
-        this.usersSource ? ` and ${users.length} users` : ''
-      }`,
+      } entities from ${workgroups.length} workgroups and ${
+        users.length
+      } users`,
     );
   }
 

--- a/plugins/catalog-backend-module-mozcloud/src/MozcloudWorkgroupEntityProvider.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/MozcloudWorkgroupEntityProvider.ts
@@ -1,7 +1,10 @@
 import {
   LoggerService,
+  readSchedulerServiceTaskScheduleDefinitionFromConfig,
+  SchedulerService,
   SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import {
   EntityProvider,
@@ -10,7 +13,25 @@ import {
 import { Source } from './sources/Source';
 import { workgroupToEntities } from './transform/workgroupToEntities';
 import { userToEntities } from './transform/userToEntities';
-import { UserRow, WorkgroupRow } from './transform/schema';
+import {
+  UserRow,
+  UserRowSchema,
+  WorkgroupRow,
+  WorkgroupRowSchema,
+} from './transform/schema';
+import { defineBigQuerySource } from './sources/BigQuerySource';
+import {
+  usersQuery,
+  usersSourceDescription,
+  workgroupsQuery,
+  workgroupsSourceDescription,
+} from './queries';
+
+const DEFAULT_SCHEDULE = {
+  frequency: { minutes: 30 },
+  timeout: { minutes: 5 },
+  initialDelay: { seconds: 30 },
+};
 
 /**
  * Catalog entity provider for Mozilla workgroups.
@@ -20,23 +41,24 @@ import { UserRow, WorkgroupRow } from './transform/schema';
  *    Drives Group entities (workgroup + subgroup), both in the
  *    `workgroups` namespace so they don't collide with the GitHub Org
  *    provider's Groups in `default`.
- *  - optional `users` source — one row per human user, with GitHub
+ *  - `users` source — one row per human user, with GitHub
  *    metadata and the `(workgroup, subgroup)` memberships they hold.
  *    Drives User entities in the `workgroups` namespace and back-fills
  *    each subgroup's `spec.members` so Group pages list humans.
- *
- * Without a users source the provider still emits Groups; subgroup
- * `spec.members` stays empty and no User entities are produced.
  */
 export class MozcloudWorkgroupEntityProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
 
+  readonly description: string;
+
   constructor(
-    private readonly source: Source<WorkgroupRow>,
+    private readonly workgroupsSource: Source<WorkgroupRow>,
+    private readonly usersSource: Source<UserRow>,
     private readonly logger: LoggerService,
     private readonly taskRunner: SchedulerServiceTaskRunner,
-    private readonly usersSource?: Source<UserRow>,
-  ) {}
+  ) {
+    this.description = `workgroups: ${workgroupsSource.description}, users: ${usersSource.description}`;
+  }
 
   getProviderName(): string {
     return 'MozcloudWorkgroupEntityProvider';
@@ -67,11 +89,11 @@ export class MozcloudWorkgroupEntityProvider implements EntityProvider {
     }
 
     const [workgroups, users] = await Promise.all([
-      this.source.fetchAll(),
+      this.workgroupsSource.fetchAll(),
       this.usersSource ? this.usersSource.fetchAll() : Promise.resolve([]),
     ]);
 
-    const wgLocationRef = `mozcloud-workgroups:${this.source.description}`;
+    const wgLocationRef = `mozcloud-workgroups:${this.workgroupsSource.description}`;
     const userLocationRef = this.usersSource
       ? `mozcloud-users:${this.usersSource.description}`
       : wgLocationRef;
@@ -100,6 +122,61 @@ export class MozcloudWorkgroupEntityProvider implements EntityProvider {
       } entities from ${workgroups.length} workgroups${
         this.usersSource ? ` and ${users.length} users` : ''
       }`,
+    );
+  }
+
+  /**
+   * Build a provider from its `catalog.providers.mozcloud.workgroups`
+   * config block.
+   */
+  static createFromConfig(
+    config: Config,
+    logger: LoggerService,
+    scheduler: SchedulerService,
+  ): MozcloudWorkgroupEntityProvider {
+    const wgBq = config.getConfig('sources.workgroups.bigquery').get<{
+      project: string;
+      dataset: string;
+      workgroupsTable?: string;
+      billingProject?: string;
+    }>();
+    const workgroupsSource = defineBigQuerySource({
+      query: workgroupsQuery(wgBq),
+      schema: WorkgroupRowSchema,
+      description: workgroupsSourceDescription(wgBq),
+      billingProject: wgBq.billingProject,
+      dataProject: wgBq.project,
+      logger,
+    });
+
+    const usersCfg = config.getConfig('sources.users.bigquery');
+    const usersBq = usersCfg.get<{
+      project: string;
+      dataset: string;
+      subgroupMembersTable?: string;
+      billingProject?: string;
+    }>();
+    const usersSource = defineBigQuerySource({
+      query: usersQuery(usersBq),
+      schema: UserRowSchema,
+      description: usersSourceDescription(usersBq),
+      billingProject: usersBq.billingProject,
+      dataProject: usersBq.project,
+      logger,
+    });
+
+    const schedule = config.has('schedule')
+      ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
+          config.getConfig('schedule'),
+        )
+      : DEFAULT_SCHEDULE;
+    const taskRunner = scheduler.createScheduledTaskRunner(schedule);
+
+    return new MozcloudWorkgroupEntityProvider(
+      workgroupsSource,
+      usersSource,
+      logger,
+      taskRunner,
     );
   }
 }

--- a/plugins/catalog-backend-module-mozcloud/src/module.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/module.ts
@@ -65,6 +65,7 @@ export const catalogModuleMozcloud = createBackendModule({
             project: string;
             dataset: string;
             table: string;
+            billingProject?: string;
           }>();
           const schedule = tenantsCfg.has('schedule')
             ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
@@ -75,6 +76,7 @@ export const catalogModuleMozcloud = createBackendModule({
             query: tenantsQuery(tenantsBq),
             schema: TenantRowSchema,
             description: `bigquery:${tenantsBq.project}.${tenantsBq.dataset}.${tenantsBq.table}`,
+            billingProject: tenantsBq.billingProject,
             dataProject: tenantsBq.project,
             normalize: normalizeTenantRow,
             logger,
@@ -91,11 +93,13 @@ export const catalogModuleMozcloud = createBackendModule({
               dataset: string;
               tenantsTable?: string;
               deployedChartsTable?: string;
+              billingProject?: string;
             }>();
             chartsSource = defineBigQuerySource({
               query: chartsDeploymentsQuery(chartsBq),
               schema: ChartDeploymentsRowSchema,
               description: chartsDeploymentsSourceDescription(chartsBq),
+              billingProject: chartsBq.billingProject,
               dataProject: chartsBq.project,
               logger,
             });
@@ -123,6 +127,7 @@ export const catalogModuleMozcloud = createBackendModule({
             project: string;
             dataset: string;
             workgroupsTable?: string;
+            billingProject?: string;
           }>();
           const schedule = wgCfg.has('schedule')
             ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
@@ -133,6 +138,7 @@ export const catalogModuleMozcloud = createBackendModule({
             query: workgroupsQuery(wgBq),
             schema: WorkgroupRowSchema,
             description: workgroupsSourceDescription(wgBq),
+            billingProject: wgBq.billingProject,
             dataProject: wgBq.project,
             logger,
           });
@@ -147,11 +153,13 @@ export const catalogModuleMozcloud = createBackendModule({
               project: string;
               dataset: string;
               subgroupMembersTable?: string;
+              billingProject?: string;
             }>();
             usersSource = defineBigQuerySource({
               query: usersQuery(usersBq),
               schema: UserRowSchema,
               description: usersSourceDescription(usersBq),
+              billingProject: usersBq.billingProject,
               dataProject: usersBq.project,
               logger,
             });

--- a/plugins/catalog-backend-module-mozcloud/src/module.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/module.ts
@@ -1,43 +1,18 @@
 import {
   coreServices,
   createBackendModule,
-  readSchedulerServiceTaskScheduleDefinitionFromConfig,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { MozcloudTenantEntityProvider } from './MozcloudTenantEntityProvider';
 import { MozcloudWorkgroupEntityProvider } from './MozcloudWorkgroupEntityProvider';
-import {
-  defineBigQuerySource,
-  normalizeTenantRow,
-} from './sources/BigQuerySource';
-import {
-  chartsDeploymentsQuery,
-  chartsDeploymentsSourceDescription,
-  tenantsQuery,
-  usersQuery,
-  usersSourceDescription,
-  workgroupsQuery,
-  workgroupsSourceDescription,
-} from './queries';
-import {
-  ChartDeploymentsRowSchema,
-  TenantRowSchema,
-  UserRowSchema,
-  WorkgroupRowSchema,
-} from './transform/schema';
-
-const DEFAULT_SCHEDULE = {
-  frequency: { minutes: 30 },
-  timeout: { minutes: 5 },
-  initialDelay: { seconds: 30 },
-};
 
 /**
  * Backstage backend module that registers the mozcloud tenant and
  * workgroup catalog entity providers under the existing catalog plugin.
  *
  * Configuration lives under `catalog.providers.mozcloud` — see config.d.ts.
- * Each provider requires a `bigquery` block; auth follows ADC.
+ * Each provider owns its own BigQuery wiring via `createFromConfig`; this
+ * module just hands the right config block to each.
  */
 export const catalogModuleMozcloud = createBackendModule({
   pluginId: 'catalog',
@@ -61,123 +36,27 @@ export const catalogModuleMozcloud = createBackendModule({
 
         const tenantsCfg = root.getOptionalConfig('tenants');
         if (tenantsCfg) {
-          const tenantsBq = tenantsCfg.getConfig('bigquery').get<{
-            project: string;
-            dataset: string;
-            table: string;
-            billingProject?: string;
-          }>();
-          const schedule = tenantsCfg.has('schedule')
-            ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
-                tenantsCfg.getConfig('schedule'),
-              )
-            : DEFAULT_SCHEDULE;
-          const source = defineBigQuerySource({
-            query: tenantsQuery(tenantsBq),
-            schema: TenantRowSchema,
-            description: `bigquery:${tenantsBq.project}.${tenantsBq.dataset}.${tenantsBq.table}`,
-            billingProject: tenantsBq.billingProject,
-            dataProject: tenantsBq.project,
-            normalize: normalizeTenantRow,
+          const provider = MozcloudTenantEntityProvider.createFromConfig(
+            tenantsCfg,
             logger,
-          });
-
-          // Optional second source: actual deployment tree per chart.
-          // The tenant provider correlates rows by (tenant, chart_name)
-          // and enriches the corresponding chart Components.
-          const chartsCfg = root.getOptionalConfig('charts');
-          let chartsSource;
-          if (chartsCfg) {
-            const chartsBq = chartsCfg.getConfig('bigquery').get<{
-              project: string;
-              dataset: string;
-              tenantsTable?: string;
-              deployedChartsTable?: string;
-              billingProject?: string;
-            }>();
-            chartsSource = defineBigQuerySource({
-              query: chartsDeploymentsQuery(chartsBq),
-              schema: ChartDeploymentsRowSchema,
-              description: chartsDeploymentsSourceDescription(chartsBq),
-              billingProject: chartsBq.billingProject,
-              dataProject: chartsBq.project,
-              logger,
-            });
-          }
-
-          const taskRunner = scheduler.createScheduledTaskRunner(schedule);
-          catalog.addEntityProvider(
-            new MozcloudTenantEntityProvider(
-              source,
-              logger,
-              taskRunner,
-              chartsSource,
-            ),
+            scheduler,
           );
+          catalog.addEntityProvider(provider);
           logger.info(
-            `Registered mozcloud tenant provider (tenants: ${
-              source.description
-            }${chartsSource ? `, charts: ${chartsSource.description}` : ''})`,
+            `Registered mozcloud tenant provider (${provider.description})`,
           );
         }
 
         const wgCfg = root.getOptionalConfig('workgroups');
         if (wgCfg) {
-          const wgBq = wgCfg.getConfig('bigquery').get<{
-            project: string;
-            dataset: string;
-            workgroupsTable?: string;
-            billingProject?: string;
-          }>();
-          const schedule = wgCfg.has('schedule')
-            ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
-                wgCfg.getConfig('schedule'),
-              )
-            : DEFAULT_SCHEDULE;
-          const source = defineBigQuerySource({
-            query: workgroupsQuery(wgBq),
-            schema: WorkgroupRowSchema,
-            description: workgroupsSourceDescription(wgBq),
-            billingProject: wgBq.billingProject,
-            dataProject: wgBq.project,
+          const provider = MozcloudWorkgroupEntityProvider.createFromConfig(
+            wgCfg,
             logger,
-          });
-
-          // Optional second source: human users with GitHub identity and
-          // per-user (workgroup, subgroup) memberships. Drives User
-          // entity emission and back-fills subgroup Group members.
-          const usersCfg = root.getOptionalConfig('users');
-          let usersSource;
-          if (usersCfg) {
-            const usersBq = usersCfg.getConfig('bigquery').get<{
-              project: string;
-              dataset: string;
-              subgroupMembersTable?: string;
-              billingProject?: string;
-            }>();
-            usersSource = defineBigQuerySource({
-              query: usersQuery(usersBq),
-              schema: UserRowSchema,
-              description: usersSourceDescription(usersBq),
-              billingProject: usersBq.billingProject,
-              dataProject: usersBq.project,
-              logger,
-            });
-          }
-
-          const taskRunner = scheduler.createScheduledTaskRunner(schedule);
-          catalog.addEntityProvider(
-            new MozcloudWorkgroupEntityProvider(
-              source,
-              logger,
-              taskRunner,
-              usersSource,
-            ),
+            scheduler,
           );
+          catalog.addEntityProvider(provider);
           logger.info(
-            `Registered mozcloud workgroup provider (workgroups: ${
-              source.description
-            }${usersSource ? `, users: ${usersSource.description}` : ''})`,
+            `Registered mozcloud workgroup provider (${provider.description})`,
           );
         }
       },

--- a/plugins/catalog-backend-module-mozcloud/src/sources/BigQuerySource.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/sources/BigQuerySource.ts
@@ -11,9 +11,15 @@ interface DefineBigQuerySourceOptions<T> {
   /** Stable identifier — used in log lines and as the provider's location key. */
   description: string;
   /**
-   * Project the BigQuery client targets. Jobs are created and billed
-   * against this project, so the calling identity must hold
-   * `bigquery.jobs.create` on it.
+   * Project under which BQ jobs are created and billed. Defaults to ADC's
+   * quota project. Lets the caller read tables in another project (e.g.
+   * `mozdata`) while paying jobs out of a project where they have
+   * `bigquery.jobs.create`.
+   */
+  billingProject?: string;
+  /**
+   * Project the BigQuery client targets when no `billingProject` is set.
+   * Mostly a convenience to make the resolved project explicit in logs.
    */
   dataProject?: string;
   /**
@@ -37,7 +43,7 @@ interface DefineBigQuerySourceOptions<T> {
  *
  * - **Auth/billing** — the BigQuery client uses ADC (Workload Identity
  *   in GKE, application-default credentials locally) and bills jobs to
- *   the `dataProject`.
+ *   `billingProject` if set, otherwise the data project.
  * - **Null-strip** — BigQuery returns `null` for missing optional
  *   fields. Zod's `.optional()` permits `undefined` but not `null`, so
  *   every row is passed through a recursive null-strip before
@@ -57,7 +63,7 @@ export function defineBigQuerySource<T>(
   const bq =
     opts.bq ??
     new BigQuery({
-      projectId: opts.dataProject,
+      projectId: opts.billingProject ?? opts.dataProject,
     });
 
   return {

--- a/plugins/catalog-backend-module-mozcloud/src/sources/BigQuerySource.ts
+++ b/plugins/catalog-backend-module-mozcloud/src/sources/BigQuerySource.ts
@@ -6,10 +6,13 @@ import { Source } from './Source';
 interface DefineBigQuerySourceOptions<T> {
   /** Full SQL to execute, including any JOINs, CTEs, or projections. */
   query: string;
+
   /** Validated per row; bad rows are skipped and logged. */
   schema: ZodType<T, ZodTypeDef, unknown>;
+
   /** Stable identifier — used in log lines and as the provider's location key. */
   description: string;
+
   /**
    * Project under which BQ jobs are created and billed. Defaults to ADC's
    * quota project. Lets the caller read tables in another project (e.g.
@@ -17,11 +20,13 @@ interface DefineBigQuerySourceOptions<T> {
    * `bigquery.jobs.create`.
    */
   billingProject?: string;
+
   /**
    * Project the BigQuery client targets when no `billingProject` is set.
    * Mostly a convenience to make the resolved project explicit in logs.
    */
   dataProject?: string;
+
   /**
    * Optional pre-validation hook for BigQuery quirks the schema doesn't
    * handle directly — most commonly converting REPEATED RECORD columns
@@ -31,7 +36,9 @@ interface DefineBigQuerySourceOptions<T> {
    * normalize function sees a tree with no `null` values.
    */
   normalize?: (row: Record<string, unknown>) => unknown;
+
   logger: LoggerService;
+
   /** Injectable for tests; defaults to a freshly-constructed client. */
   bq?: BigQuery;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,6 +2979,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "@backstage/config@npm:1.3.8"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10c0/bd9e1fdd7ab8e56a9814a7f67502ed69f9abd0f014dae44d253a6a02c0c6bf844451d037afa991b200fc09d89e7195593bd5a9459357dafd8101dc826e664dec
+  languageName: node
+  linkType: hard
+
 "@backstage/core-app-api@npm:^1.20.0":
   version: 1.20.0
   resolution: "@backstage/core-app-api@npm:1.20.0"
@@ -3165,6 +3176,16 @@ __metadata:
     "@backstage/types": "npm:^1.2.2"
     serialize-error: "npm:^8.0.1"
   checksum: 10c0/e47f4a42d989858ab148359a410a82e295b5090c3da8d3a761997fd95d41786183c4113d8db13525964d497c2963e2d532c32f93548bb35bd30c1b514c34af19
+  languageName: node
+  linkType: hard
+
+"@backstage/errors@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/errors@npm:1.3.1"
+  dependencies:
+    "@backstage/types": "npm:^1.2.2"
+    serialize-error: "npm:^8.0.1"
+  checksum: 10c0/b342551f5337f17bcc6d412868f6274509d657cc6037fbb5af96d42156c24c2419e72fd711136e42d05245bd4e5c5d8fe9cd54f89f260d9285a073c28cca0261
   languageName: node
   linkType: hard
 
@@ -5996,6 +6017,7 @@ __metadata:
     "@backstage/backend-test-utils": "npm:^1.11.0"
     "@backstage/catalog-model": "npm:^1.8.0"
     "@backstage/cli": "npm:^0.36.1"
+    "@backstage/config": "npm:^1.3.8"
     "@backstage/plugin-catalog-node": "npm:^2.2.0"
     "@google-cloud/bigquery": "npm:^8.3.0"
     "@types/js-yaml": "npm:^4.0.9"


### PR DESCRIPTION
Adds a default billing project for bigquery sources. will default to nonprod for development and staging and be set to prod for production.

https://mozilla-hub.atlassian.net/browse/MZCLD-3137

I also included a refactor of the mozcloud entity provider configuration